### PR TITLE
Added case for RaC Trilogy disk version

### DIFF
--- a/RaCTrainer/AttachPS3Form.cs
+++ b/RaCTrainer/AttachPS3Form.cs
@@ -110,6 +110,26 @@ namespace racman
                 return;
             }
 
+            if (game == "BCES01503")
+            {
+                var diskGameSelector = new DiskGameSelector();
+                if (diskGameSelector.ShowDialog() == DialogResult.OK)
+                {
+                    switch (diskGameSelector.GetSelectedVersion())
+                    {
+                        case 0:
+                            game = "NPEA00385"; // RAC 1
+                            break;
+                        case 1:
+                            game = "NPEA00386"; // RAC 2
+                            break;
+                        case 2:
+                            game = "NPEA00387"; // RAC 3
+                            break;  
+                    }
+                }
+            } // if disk version was found, the following code can be executed as if this check never happened
+
             if (game == "NPEA00385")
             {
                 Hide();

--- a/RaCTrainer/DiskGameSelector.Designer.cs
+++ b/RaCTrainer/DiskGameSelector.Designer.cs
@@ -1,0 +1,86 @@
+﻿using System.ComponentModel;
+
+namespace racman
+{
+    partial class DiskGameSelector
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.Select = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Items.AddRange(new object[] { "Ratchet & Clank 1", "Ratchet & Clank 2", "Ratchet & Clank 3" });
+            this.comboBox1.Location = new System.Drawing.Point(31, 44);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(121, 21);
+            this.comboBox1.TabIndex = 0;
+            // 
+            // Select
+            // 
+            this.Select.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Select.Location = new System.Drawing.Point(53, 71);
+            this.Select.Name = "Select";
+            this.Select.Size = new System.Drawing.Size(75, 23);
+            this.Select.TabIndex = 1;
+            this.Select.Text = "select";
+            this.Select.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.label1.Location = new System.Drawing.Point(31, 18);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(138, 23);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Please select game version";
+            // 
+            // DiskGameSelector
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(189, 125);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.Select);
+            this.Controls.Add(this.comboBox1);
+            this.Name = "DiskGameSelector";
+            this.Text = "DiskGameSelector";
+            this.ResumeLayout(false);
+        }
+
+        private System.Windows.Forms.Label label1;
+
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.Button Select;
+
+        #endregion
+    }
+}

--- a/RaCTrainer/DiskGameSelector.cs
+++ b/RaCTrainer/DiskGameSelector.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Windows.Forms;
+
+namespace racman
+{
+    public partial class DiskGameSelector : Form
+    {
+        public DiskGameSelector()
+        {
+            InitializeComponent();
+        }
+
+        public int GetSelectedVersion()
+        {
+            return this.comboBox1.SelectedIndex;
+        }
+    }
+}

--- a/RaCTrainer/DiskGameSelector.resx
+++ b/RaCTrainer/DiskGameSelector.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/RaCTrainer/racman.csproj
+++ b/RaCTrainer/racman.csproj
@@ -108,6 +108,12 @@
     <Compile Include="ConfigureCombos.Designer.cs">
       <DependentUpon>ConfigureCombos.cs</DependentUpon>
     </Compile>
+    <Compile Include="DiskGameSelector.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="DiskGameSelector.Designer.cs">
+      <DependentUpon>DiskGameSelector.cs</DependentUpon>
+    </Compile>
     <Compile Include="MemoryForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -207,6 +213,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ConfigureCombos.resx">
       <DependentUpon>ConfigureCombos.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DiskGameSelector.resx">
+      <DependentUpon>DiskGameSelector.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MemoryForm.resx">
       <DependentUpon>MemoryForm.cs</DependentUpon>


### PR DESCRIPTION
This enables a pop-up window to show when trilogy disk version is detected. 
The window promts the user to select their version of RaC.
Depending on the decision, the "game" variable is set to the digital version number of the selected game.
Then independent of wether this conditional statement was entered, the original code is ran to check which game is open.