### PR TITLE
Rac3 autosplitter bugfixes and improvement

### DIFF
--- a/RaCTrainer/AutosplitterHelper.cs
+++ b/RaCTrainer/AutosplitterHelper.cs
@@ -93,6 +93,7 @@ namespace racman
             {
                 writer.Seek(mmfAddressBytes, SeekOrigin.Begin);
                 writer.Write(value, 0, value.Length);
+                writer.Write(Enumerable.Repeat((byte)0, mmfConfigBytes - value.Length).ToArray());
             }    
 
             writeLock.ReleaseMutex();

--- a/RaCTrainer/autosplitters/rac3-autosplitter.asl
+++ b/RaCTrainer/autosplitters/rac3-autosplitter.asl
@@ -13,6 +13,8 @@ startup {
     settings.SetToolTip("BIO_SPLIT", "Splits on defeating the biobliterator, the final boss.");
     settings.Add("COUNT_LONG_LOADS", false, "Use long load counter");
     settings.SetToolTip("COUNT_LONG_LOADS", "Count the long loads in a text component. Requires a text component with the left text set to \"Long Loads\".");
+    settings.Add("LDF_SPLIT", false, "Split when entering LDF");
+    settings.SetToolTip("LDF_SPLIT", "Splits when entering the laser defence facility on Marcadia. Does not split on exit.");
 }
 
 init {
@@ -31,6 +33,7 @@ init {
     current.mission = vars.reader.ReadByte();
     current.neffyHealth = vars.reader.ReadSingle();
     current.neffyPhase = vars.reader.ReadUInt32();
+    current.chunk = vars.reader.ReadInt32();
 
     vars.reader.BaseStream.Position = 128;
     vars.SplitRoute = vars.reader.ReadBytes(128);
@@ -74,6 +77,7 @@ update {
     current.mission = vars.reader.ReadByte();
     current.neffyHealth = vars.reader.ReadSingle();
     current.neffyPhase = vars.reader.ReadUInt32();
+    current.chunk = vars.reader.ReadInt32();
 
     vars.reader.BaseStream.Position = 128;
     vars.SplitRoute = vars.reader.ReadBytes(128);
@@ -107,6 +111,11 @@ start {
 }
 
 split {
+    if (settings["LDF_SPLIT"] && current.planet == 4 && current.chunk == 1 && old.chunk != 1)
+    {
+        vars.SplitCount++;
+        return true;
+    }
     if (current.neffyHealth == 0 && vars.biobliterator && current.planet == 20 && settings["BIO_SPLIT"]) {
         vars.biobliterator = false;
         vars.SplitCount++;

--- a/RaCTrainer/autosplitters/rac3-autosplitter.asl
+++ b/RaCTrainer/autosplitters/rac3-autosplitter.asl
@@ -36,7 +36,7 @@ init {
     current.chunk = vars.reader.ReadInt32();
 
     vars.reader.BaseStream.Position = 128;
-    vars.SplitRoute = vars.reader.ReadBytes(128);
+    vars.SplitRoute = vars.reader.ReadBytes(256);
 
     vars.SplitCount = 0;
     vars.biobliterator = false;
@@ -80,7 +80,7 @@ update {
     current.chunk = vars.reader.ReadInt32();
 
     vars.reader.BaseStream.Position = 128;
-    vars.SplitRoute = vars.reader.ReadBytes(128);
+    vars.SplitRoute = vars.reader.ReadBytes(256);
 
     if (current.loadingScreen == 1 && old.loadingScreen != 1 && vars.shipLevels.Contains(current.destinationPlanet)) {
         // Count a long load

--- a/RaCTrainer/offsets/rac3.cs
+++ b/RaCTrainer/offsets/rac3.cs
@@ -22,6 +22,7 @@ namespace racman
         public uint deathCount => 0xED7F14;
         public uint planetFrameCount => 0x1A70B30;
         public uint marcadiaMission => 0xD3AABC;
+        public uint loadedChunk => 0xF08100;
 
         // Player variables
         public uint boltCount => 0xc1e4dc;
@@ -196,7 +197,8 @@ namespace racman
             (addr.loadingScreenID + 3, 1),
             (addr.marcadiaMission + 3, 1), // Not actually used, here for backwards compatibility
             (0xC4DF80, 4),
-            (0xDA50FC, 4)
+            (0xDA50FC, 4),
+            (addr.loadedChunk, 4)
         };
 
         public void KlunkTuneToggle(bool enabled)


### PR DESCRIPTION
- Added an option to the rac3 autosplitter that splits on entering the Laser Defence Facility in Marcadia
- Fixed a bug in the rac3 autosplitter that could trigger if the selected split route was changed without restarting RacMAN
- Fixed a bug in the rac3 autosplitter that made the split route length limit 64 instead of the intended 128