### PR TITLE
ACIT autosplitter is finally working + minor improvements

### DIFF
--- a/RaCTrainer/ACIT/ACITUnlocks.cs
+++ b/RaCTrainer/ACIT/ACITUnlocks.cs
@@ -23,10 +23,9 @@ namespace racman
                 weaponsCheckList.Items.Add(weaponName, weapons[i].isUnlocked);
                 weaponsCheckList.SetItemChecked(i, weapons[i].isUnlocked);
 
-                weapons[i].levelChanged += (s, e) =>
+                weapons[i].levelChanged += (weapon) =>
                 {
-                    // get the index of the weapon that changed
-                    int index = weapons.IndexOf((ACITWeapon)s);
+                    int index = weapons.IndexOf(weapon);
                     weaponsCheckList.Items[index] = weapons[index].name + $" [{weapons[index].level}]";
                 };
             }

--- a/RaCTrainer/ACIT/ACITUnlocks.cs
+++ b/RaCTrainer/ACIT/ACITUnlocks.cs
@@ -20,8 +20,8 @@ namespace racman
             for (int i = 0; i < weapons.Count; i++)
             {
                 String weaponName = weapons[i].name + $" [{weapons[i].level}]";
-                weaponsCheckList.Items.Add(weaponName, weapons[i].isUnlocked);
-                weaponsCheckList.SetItemChecked(i, weapons[i].isUnlocked);
+                weaponsCheckList.Items.Add(weaponName, weapons[i].IsUnlocked);
+                weaponsCheckList.SetItemChecked(i, weapons[i].IsUnlocked);
 
                 weapons[i].levelChanged += (weapon) =>
                 {

--- a/RaCTrainer/ACIT/ACITUnlocks.cs
+++ b/RaCTrainer/ACIT/ACITUnlocks.cs
@@ -19,15 +19,22 @@ namespace racman
 
             for (int i = 0; i < weapons.Count; i++)
             {
-                weaponsCheckList.Items.Add(weapons[i].name, weapons[i].isUnlocked);
+                String weaponName = weapons[i].name + $" [{weapons[i].level}]";
+                weaponsCheckList.Items.Add(weaponName, weapons[i].isUnlocked);
                 weaponsCheckList.SetItemChecked(i, weapons[i].isUnlocked);
+
+                weapons[i].levelChanged += (s, e) =>
+                {
+                    // get the index of the weapon that changed
+                    int index = weapons.IndexOf((ACITWeapon)s);
+                    weaponsCheckList.Items[index] = weapons[index].name + $" [{weapons[index].level}]";
+                };
             }
 
             weaponsCheckList.ItemCheck += (s, e) =>
             {
                 game.setUnlockState(weapons[e.Index], e.NewValue == CheckState.Checked);
             };
-
         }
 
         private void buttonUnlockAll_Click(object sender, EventArgs e)

--- a/RaCTrainer/RAC4/RAC4BotsUnlocks.Designer.cs
+++ b/RaCTrainer/RAC4/RAC4BotsUnlocks.Designer.cs
@@ -1,0 +1,101 @@
+﻿namespace racman
+{
+    partial class RAC4BotsUnlocks
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.toolTip2 = new System.Windows.Forms.ToolTip(this.components);
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.buttonRemoveAll = new System.Windows.Forms.Button();
+            this.buttonUnlockAll = new System.Windows.Forms.Button();
+            this.lbUnlockAll = new System.Windows.Forms.Label();
+            this.botsUnlocksCheckList = new System.Windows.Forms.CheckedListBox();
+            this.SuspendLayout();
+            // 
+            // buttonRemoveAll
+            // 
+            this.buttonRemoveAll.Location = new System.Drawing.Point(12, 22);
+            this.buttonRemoveAll.Name = "buttonRemoveAll";
+            this.buttonRemoveAll.Size = new System.Drawing.Size(178, 24);
+            this.buttonRemoveAll.TabIndex = 54;
+            this.buttonRemoveAll.Text = "Remove All";
+            this.buttonRemoveAll.UseVisualStyleBackColor = true;
+            this.buttonRemoveAll.Click += new System.EventHandler(this.buttonRemoveAll_Click);
+            // 
+            // buttonUnlockAll
+            // 
+            this.buttonUnlockAll.Location = new System.Drawing.Point(211, 22);
+            this.buttonUnlockAll.Name = "buttonUnlockAll";
+            this.buttonUnlockAll.Size = new System.Drawing.Size(178, 24);
+            this.buttonUnlockAll.TabIndex = 53;
+            this.buttonUnlockAll.Text = "Unlock All";
+            this.buttonUnlockAll.UseVisualStyleBackColor = true;
+            this.buttonUnlockAll.Click += new System.EventHandler(this.buttonUnlockAll_Click);
+            // 
+            // lbUnlockAll
+            // 
+            this.lbUnlockAll.AutoSize = true;
+            this.lbUnlockAll.Location = new System.Drawing.Point(9, 6);
+            this.lbUnlockAll.Name = "lbUnlockAll";
+            this.lbUnlockAll.Size = new System.Drawing.Size(46, 13);
+            this.lbUnlockAll.TabIndex = 52;
+            this.lbUnlockAll.Text = "Unlocks";
+            // 
+            // botsUnlocksCheckList
+            // 
+            this.botsUnlocksCheckList.FormattingEnabled = true;
+            this.botsUnlocksCheckList.Location = new System.Drawing.Point(12, 67);
+            this.botsUnlocksCheckList.Name = "botsUnlocksCheckList";
+            this.botsUnlocksCheckList.Size = new System.Drawing.Size(377, 574);
+            this.botsUnlocksCheckList.TabIndex = 51;
+            // 
+            // RAC4BotsUnlocks
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(401, 670);
+            this.Controls.Add(this.buttonRemoveAll);
+            this.Controls.Add(this.buttonUnlockAll);
+            this.Controls.Add(this.lbUnlockAll);
+            this.Controls.Add(this.botsUnlocksCheckList);
+            this.Name = "RAC4BotsUnlocks";
+            this.Text = "RAC4BotsUnlocks";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.ToolTip toolTip2;
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Button buttonRemoveAll;
+        private System.Windows.Forms.Button buttonUnlockAll;
+        private System.Windows.Forms.Label lbUnlockAll;
+        private System.Windows.Forms.CheckedListBox botsUnlocksCheckList;
+    }
+}

--- a/RaCTrainer/RAC4/RAC4BotsUnlocks.cs
+++ b/RaCTrainer/RAC4/RAC4BotsUnlocks.cs
@@ -1,0 +1,57 @@
+﻿using racman.offsets;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace racman
+{
+    public partial class RAC4BotsUnlocks : Form
+    {
+        private rac4 game;
+
+        private List<ACITWeapon> unlocks = new List<ACITWeapon>();
+
+        public RAC4BotsUnlocks(rac4 game)
+        {
+            this.game = game;
+            //unlocks = game.GetWeapons();
+            InitializeComponent();
+
+            for (int i = 0; i < unlocks.Count; i++)
+            {
+                String weaponName = unlocks[i].name + $" [{unlocks[i].level}]";
+                botsUnlocksCheckList.Items.Add(weaponName, unlocks[i].isUnlocked);
+                botsUnlocksCheckList.SetItemChecked(i, unlocks[i].isUnlocked);
+
+                unlocks[i].levelChanged += (weapon) =>
+                {
+                    int index = unlocks.IndexOf(weapon);
+                    botsUnlocksCheckList.Items[index] = unlocks[index].name + $" [{unlocks[index].level}]";
+                };
+            }
+
+            botsUnlocksCheckList.ItemCheck += (s, e) =>
+            {
+                //game.SetUnlockState(unlocks[e.Index], e.NewValue == CheckState.Checked);
+            };
+        }
+
+        private void buttonUnlockAll_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < unlocks.Count; i++)
+            {
+                botsUnlocksCheckList.SetItemChecked(i, true);
+                //game.setUnlockState(unlocks[i], true);
+            }
+        }
+
+        private void buttonRemoveAll_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < unlocks.Count; i++)
+            {
+                botsUnlocksCheckList.SetItemChecked(i, false);
+                //game.setUnlockState(unlocks[i], false);
+            }
+        }
+    }
+}

--- a/RaCTrainer/RAC4/RAC4BotsUnlocks.cs
+++ b/RaCTrainer/RAC4/RAC4BotsUnlocks.cs
@@ -1,4 +1,4 @@
-﻿using racman.offsets;
+﻿using racman.offsets.RAC4;
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
@@ -9,30 +9,23 @@ namespace racman
     {
         private rac4 game;
 
-        private List<ACITWeapon> unlocks = new List<ACITWeapon>();
+        private List<BotsUnlocks> unlocks;
 
         public RAC4BotsUnlocks(rac4 game)
         {
             this.game = game;
-            //unlocks = game.GetWeapons();
+            unlocks = game.GetBotsUnlocks();
             InitializeComponent();
 
             for (int i = 0; i < unlocks.Count; i++)
             {
-                String weaponName = unlocks[i].name + $" [{unlocks[i].level}]";
-                botsUnlocksCheckList.Items.Add(weaponName, unlocks[i].isUnlocked);
-                botsUnlocksCheckList.SetItemChecked(i, unlocks[i].isUnlocked);
-
-                unlocks[i].levelChanged += (weapon) =>
-                {
-                    int index = unlocks.IndexOf(weapon);
-                    botsUnlocksCheckList.Items[index] = unlocks[index].name + $" [{unlocks[index].level}]";
-                };
+                botsUnlocksCheckList.Items.Add(unlocks[i].name, unlocks[i].IsUnlocked);
+                botsUnlocksCheckList.SetItemChecked(i, unlocks[i].IsUnlocked);
             }
 
             botsUnlocksCheckList.ItemCheck += (s, e) =>
             {
-                //game.SetUnlockState(unlocks[e.Index], e.NewValue == CheckState.Checked);
+                game.SetUnlockState(unlocks[e.Index], e.NewValue == CheckState.Checked);
             };
         }
 
@@ -41,7 +34,7 @@ namespace racman
             for (int i = 0; i < unlocks.Count; i++)
             {
                 botsUnlocksCheckList.SetItemChecked(i, true);
-                //game.setUnlockState(unlocks[i], true);
+                game.SetUnlockState(unlocks[i], true);
             }
         }
 
@@ -50,7 +43,7 @@ namespace racman
             for (int i = 0; i < unlocks.Count; i++)
             {
                 botsUnlocksCheckList.SetItemChecked(i, false);
-                //game.setUnlockState(unlocks[i], false);
+                game.SetUnlockState(unlocks[i], false);
             }
         }
     }

--- a/RaCTrainer/RAC4/RAC4BotsUnlocks.resx
+++ b/RaCTrainer/RAC4/RAC4BotsUnlocks.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>211, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>308, 17</value>
+  </metadata>
+</root>

--- a/RaCTrainer/RAC4/RAC4Form.Designer.cs
+++ b/RaCTrainer/RAC4/RAC4Form.Designer.cs
@@ -43,6 +43,7 @@ namespace racman
             this.label8 = new System.Windows.Forms.Label();
             this.bolts_textBox = new System.Windows.Forms.TextBox();
             this.killyourself = new System.Windows.Forms.Button();
+            this.botsUnlocksWindowButton = new System.Windows.Forms.Button();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -172,11 +173,22 @@ namespace racman
             this.killyourself.UseVisualStyleBackColor = true;
             this.killyourself.Click += new System.EventHandler(this.killyourself_Click);
             // 
+            // botsUnlocksWindowButton
+            // 
+            this.botsUnlocksWindowButton.Location = new System.Drawing.Point(12, 190);
+            this.botsUnlocksWindowButton.Name = "botsUnlocksWindowButton";
+            this.botsUnlocksWindowButton.Size = new System.Drawing.Size(106, 23);
+            this.botsUnlocksWindowButton.TabIndex = 109;
+            this.botsUnlocksWindowButton.Text = "Bots Unlocks";
+            this.botsUnlocksWindowButton.UseVisualStyleBackColor = true;
+            this.botsUnlocksWindowButton.Click += new System.EventHandler(this.botsUnlocksWindowButton_Click);
+            // 
             // RAC4Form
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(629, 225);
+            this.Controls.Add(this.botsUnlocksWindowButton);
             this.Controls.Add(this.killyourself);
             this.Controls.Add(this.label8);
             this.Controls.Add(this.bolts_textBox);
@@ -217,5 +229,6 @@ namespace racman
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.TextBox bolts_textBox;
         private System.Windows.Forms.Button killyourself;
+        private System.Windows.Forms.Button botsUnlocksWindowButton;
     }
 }

--- a/RaCTrainer/RAC4/RAC4Form.cs
+++ b/RaCTrainer/RAC4/RAC4Form.cs
@@ -179,5 +179,11 @@ namespace racman
         {
             game.KillYourself();
         }
+
+        private void botsUnlocksWindowButton_Click(object sender, EventArgs e)
+        {
+            RAC4BotsUnlocks unlocks = new RAC4BotsUnlocks(game);
+            unlocks.Show();
+        }
     }
 }

--- a/RaCTrainer/autosplitters/acit-autosplitter.asl
+++ b/RaCTrainer/autosplitters/acit-autosplitter.asl
@@ -12,7 +12,7 @@ init
 
         // Read values from memory
         current.planet = vars.reader.ReadUInt32();
-        current.gameState1 = vars.reader.ReadUInt32();
+        current.gameState = vars.reader.ReadUInt32();
         current.cutsceneState1 = vars.reader.ReadUInt32();
         current.cutsceneState2 = vars.reader.ReadUInt32();
         current.cutsceneState3 = vars.reader.ReadUInt32();
@@ -24,6 +24,7 @@ init
         current.neffy1SpaceCombat = vars.reader.ReadUInt32();
         current.wasGC2Visited = vars.reader.ReadUInt32();
         current.timer = vars.reader.ReadSingle();
+        current.isLoading = vars.reader.ReadUInt32();
     });
     vars.UpdateValues();
 
@@ -33,7 +34,7 @@ init
         vars.tempTimer = 0.0f;
         vars.runSaveFileID = -1;
 
-        vars.firstVorselonVisit = true;
+        vars.startAfterLoad = false;
     });
     vars.ResetRunValues();
 }
@@ -47,7 +48,7 @@ onStart
 update
 {
     vars.UpdateValues();
-
+    
     //print(current.timer.ToString());
     //print(current.planet.ToString() + " " + old.planet.ToString());
     //print(vars.gameTime.ToString() + " " + vars.tempTimer.ToString() + " " + current.timer.ToString());
@@ -152,9 +153,17 @@ reset
         return false;
     }
 
-    // any%
-    if (current.gameState1 == 1 && old.gameState1 == 0 && current.timer == 0)
+    // if in main menu
+    if (current.gameState == 1 && old.gameState == 0 && current.timer == 0)
     {
+        print("Reset on main menu");
+        return true;
+    }
+
+    // if NG+
+    if (current.planet == 1 && old.gameState==2 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "Running"))
+    {
+        print("Reset on NG+");
         return true;
     }
 }
@@ -166,15 +175,23 @@ start
         return false;
     }
 
-    // any%
-    if (current.planet == 1 && old.gameState1==1 && current.gameState1==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
+    // if in main menu
+    if (current.planet == 1 && old.gameState==1 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
     {
-        return true;
+        print("Starting on main menu");
+        vars.startAfterLoad = true;
     }
 
-    // NG+
-    if (current.planet == 1 && old.gameState1==2 && current.gameState1==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
+    // if NG+
+    if (current.planet == 1 && old.gameState==2 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
     {
+        print("Starting on NG+");
+        vars.startAfterLoad = true;
+    }
+
+    if (vars.startAfterLoad && old.isLoading == 1 && current.isLoading == 0)
+    {
+        print("Start");
         return true;
     }
 }

--- a/RaCTrainer/autosplitters/acit-autosplitter.asl
+++ b/RaCTrainer/autosplitters/acit-autosplitter.asl
@@ -18,29 +18,22 @@ init
         current.cutsceneState3 = vars.reader.ReadUInt32();
         current.saveFileID = vars.reader.ReadUInt32();
         current.boltCounter = vars.reader.ReadUInt32();
-        current.ratchetX = vars.reader.ReadSingle();
-        current.ratchetY = vars.reader.ReadSingle();
-        current.ratchetZ = vars.reader.ReadSingle();
         current.azimuthHP = vars.reader.ReadSingle();
+        current.LibraHP = vars.reader.ReadSingle();
+        current.vorselon1SpaceCombat = vars.reader.ReadUInt32();
+        current.neffy1SpaceCombat = vars.reader.ReadUInt32();
+        current.wasGC2Visited = vars.reader.ReadUInt32();
         current.timer = vars.reader.ReadSingle();
     });
     vars.UpdateValues();
 
-    // Initialize constants
-    vars.neffy1MaxZ = 320.0f;   // this value is a bit lover than the max height of the elevator on Neffy1
-
     // Initialize run values
     vars.ResetRunValues = (Action) (() => {
-        vars.noSplitPlanets = new HashSet<int> { 3, 5, 6, 9, 10, 11, 14, 15, 18 };
         vars.gameTime = 0.0f;
         vars.tempTimer = 0.0f;
         vars.runSaveFileID = -1;
 
-        vars.korthosCutsceneCount = 0;
-        vars.isLibraAlive = true;
         vars.firstVorselonVisit = true;
-
-        vars.reachedNeffy1FinalRoom = false;
     });
     vars.ResetRunValues();
 }
@@ -58,69 +51,6 @@ update
     //print(current.timer.ToString());
     //print(current.planet.ToString() + " " + old.planet.ToString());
     //print(vars.gameTime.ToString() + " " + vars.tempTimer.ToString() + " " + current.timer.ToString());
-
-    // setting up libra fight
-    if (current.planet == 10 && old.cutsceneState2 == 0 && current.cutsceneState2 == 1 && vars.isLibraAlive)
-    {
-        vars.korthosCutsceneCount++;
-    }
-
-    // check if the save file is changed
-    if (vars.firstVorselonVisit && current.saveFileID != old.saveFileID)
-    {
-        vars.runSaveFileID = current.saveFileID;
-    }
-    
-    if (vars.firstVorselonVisit && old.planet == 3 && current.planet == 4)
-    {
-        vars.firstVorselonVisit = false;
-    }
-
-    // check if Ratchet reached the final room in Neffy1
-    if (current.planet == 17 && current.ratchetZ > vars.neffy1MaxZ)
-    {
-        vars.reachedNeffy1FinalRoom = true;
-    }
-
-    // not counting time spent during cutscenes
-    if ((old.cutsceneState2 == 0 && current.cutsceneState2 == 1) ||
-        (old.cutsceneState3 == 0 && current.cutsceneState3 == 1))
-    {
-        vars.tempTimer += current.timer;
-    }
-
-    if ((old.cutsceneState2 == 1 && current.cutsceneState2 == 0) ||
-        (old.cutsceneState3 == 1 && current.cutsceneState3 == 0))
-    {
-        vars.tempTimer -= current.timer;
-    }
-
-    if (current.cutsceneState2 == 1 || current.cutsceneState3 == 1)
-    {
-        return;
-    }
-
-    // not counting time spent on other files
-    if (current.saveFileID != vars.runSaveFileID && current.saveFileID != old.saveFileID && !vars.firstVorselonVisit)
-    {
-        vars.tempTimer += current.timer;
-    }
-
-    if (current.saveFileID == vars.runSaveFileID && current.saveFileID != old.saveFileID && !vars.firstVorselonVisit)
-    {
-        vars.tempTimer -= current.timer;
-    }
-
-    if (current.saveFileID != vars.runSaveFileID)
-    {
-        return;
-    }
-    
-    if (old.timer > current.timer)
-    {
-        vars.tempTimer += old.timer;
-    }
-    vars.gameTime = vars.tempTimer + current.timer;
 }
 
 split
@@ -130,33 +60,81 @@ split
         return false;
     }
 
-    // planet split
-    if (old.planet != current.planet && !vars.noSplitPlanets.Contains((int)old.planet))
+    // GC1
+    if (old.planet == 1 && current.planet == 2)
     {
-        print("Split on planet change " + old.planet.ToString() + " -> " + current.planet.ToString());
-        vars.noSplitPlanets.Add((int)old.planet);
+        print("Split on leaving GC1");
+        return true;
+    }
+
+    // Zolar
+    if (old.planet == 2 && current.planet == 3 && current.vorselon1SpaceCombat == 0)
+    {
+        print("Split on leaving Zolar");
+        return true;
+    }
+
+    // Vorselon 1
+    // TODO: check if ratchet is on the rigth save file
+    if (old.planet == 4 && current.planet == 3 && current.wasGC2Visited == 0)
+    {
+        print("Split on leaving Vorselon 1");
+        return true;
+    }
+
+    // Molonoth
+    if (old.planet == 7 && current.planet == 6)
+    {
+        print("Split on leaving Molonoth");
+        return true;
+    }
+
+    // Axiom
+    if (old.planet == 8 && current.planet == 6)
+    {
+        print("Split on leaving Axiom");
+        return true;
+    }
+
+    // Libra
+    if (current.planet == 10 && current.LibraHP <= 0.1f && old.cutsceneState2 == 0 && current.cutsceneState2 == 1)
+    {
+        print("Split on beating Libra");
+        return true;
+    }
+
+    // Battleplex
+    if (old.planet == 12 && current.planet == 3)
+    {
+        print("Split on leaving Battleplex");
         return true;
     }
     
-    // split on leaving Vorselon 2
+    // Vorselon 2
     if (old.planet == 4 && current.planet == 10)
     {
         print("Split on leaving Vorselon 2");
         return true;
     }
 
-    // Libra split
-    if (current.planet == 10 && vars.isLibraAlive && vars.korthosCutsceneCount == 3)
+    // Gemlik
+    if (old.planet == 19 && current.planet == 17)
     {
-        print("Split on Libra");
-        vars.isLibraAlive = false;
+        print("Split on leaving Gemlik");
         return true;
     }
 
-    // Neffy1 split (it splits if Ratchet reaches the final room and his z coord is less than the final room z coord)
-    if (current.planet == 17 && vars.reachedNeffy1FinalRoom && current.ratchetZ < vars.neffy1MaxZ)
+    // Neffy 1
+    if (current.planet == 17 && old.neffy1SpaceCombat == 1 && current.neffy1SpaceCombat == 2)
     {
-        vars.reachedNeffy1FinalRoom = false;
+        print("Split on leaving Neffy 1");
+        return true;
+    }
+
+    // Neffy 2
+    if (old.planet == 17 && current.planet == 20)
+    {
+        print("Split on leaving Neffy 2");
         return true;
     }
 

--- a/RaCTrainer/autosplitters/acit-autosplitter.asl
+++ b/RaCTrainer/autosplitters/acit-autosplitter.asl
@@ -8,19 +8,6 @@ init
 
     // Update values from memory
     vars.UpdateValues = (Action) (() => {
-        uint planet = 0;            // current planet
-        uint gameState1 = 0;        // game state1
-        uint cutsceneState1 = 0;    // cutscene state
-        uint cutsceneState2 = 0;    // cutscene state
-        uint cutsceneState3 = 0;    // cutscene state
-        uint saveFileID = 0;        // save file ID
-        uint boltCounter = 0;       // bolt counter
-        float ratchetX = 0;         // ratchet x coord
-        float ratchetY = 0;         // ratchet y coord
-        float ratchetZ = 0;         // ratchet z coord
-        float azimuthHP = 0;        // Azimuth HP
-        float acitTimer = 0;        // timer
-
         vars.reader.BaseStream.Position = 0;
 
         // Read values from memory

--- a/RaCTrainer/autosplitters/acit-autosplitter.asl
+++ b/RaCTrainer/autosplitters/acit-autosplitter.asl
@@ -25,6 +25,8 @@ init
         current.wasGC2Visited = vars.reader.ReadUInt32();
         current.timer = vars.reader.ReadSingle();
         current.isLoading = vars.reader.ReadUInt32();
+        current.firstCutscene = vars.reader.ReadUInt32();
+        current.loadSaveState = vars.reader.ReadUInt32();
     });
     vars.UpdateValues();
 
@@ -33,8 +35,6 @@ init
         vars.gameTime = 0.0f;
         vars.tempTimer = 0.0f;
         vars.runSaveFileID = -1;
-
-        vars.startAfterLoad = false;
     });
     vars.ResetRunValues();
 }
@@ -48,6 +48,12 @@ onStart
 update
 {
     vars.UpdateValues();
+
+    // update save file ID if it change is caused by a save
+    if (vars.runSaveFileID != current.saveFileID && current.loadSaveState == 1)
+    {
+        vars.runSaveFileID = current.saveFileID;
+    }
     
     //print(current.timer.ToString());
     //print(current.planet.ToString() + " " + old.planet.ToString());
@@ -76,7 +82,6 @@ split
     }
 
     // Vorselon 1
-    // TODO: check if ratchet is on the rigth save file
     if (old.planet == 4 && current.planet == 3 && current.wasGC2Visited == 0)
     {
         print("Split on leaving Vorselon 1");
@@ -161,9 +166,9 @@ reset
     }
 
     // if NG+
-    if (current.planet == 1 && old.gameState==2 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "Running"))
+    if (current.planet == 1 && old.firstCutscene == 0 && current.firstCutscene == 1)
     {
-        print("Reset on NG+");
+        print("Reset on first cutscene");
         return true;
     }
 }
@@ -175,23 +180,10 @@ start
         return false;
     }
 
-    // if in main menu
-    if (current.planet == 1 && old.gameState==1 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
+    // if the first cutscene starts
+    if (current.planet == 1 && old.firstCutscene == 0 && current.firstCutscene == 1)
     {
-        print("Starting on main menu");
-        vars.startAfterLoad = true;
-    }
-
-    // if NG+
-    if (current.planet == 1 && old.gameState==2 && current.gameState==0 && Equals(timer.CurrentPhase.ToString(), "NotRunning"))
-    {
-        print("Starting on NG+");
-        vars.startAfterLoad = true;
-    }
-
-    if (vars.startAfterLoad && old.isLoading == 1 && current.isLoading == 0)
-    {
-        print("Start");
+        print("Start on first cutscene");
         return true;
     }
 }

--- a/RaCTrainer/autosplitters/rac4-autosplitter.asl
+++ b/RaCTrainer/autosplitters/rac4-autosplitter.asl
@@ -1,5 +1,3 @@
-// Only works on PAL
-
 state("racman") { }
 
 init
@@ -10,14 +8,6 @@ init
 
     // Update values from memory
     vars.UpdateValues = (Action) (() => {
-        uint planet = 0;            // current planet
-        uint loadPlanet = 0;        // load planet
-        float voxHP = 0;            // Vox HP
-        uint cutscene = 0;          // cutscene
-        uint inGame = 0;            // in game
-        uint tutorialFlag = 0;      // tutorial flag (0 = tutorial not completed, 1 = tutorial completed)
-        uint isLoading = 0;         // loading screen (0 = not loading, 1 = loading)
-
         vars.reader.BaseStream.Position = 0;
 
         // Read values from memory

--- a/RaCTrainer/offsets/ACIT/ACITAddresses.cs
+++ b/RaCTrainer/offsets/ACIT/ACITAddresses.cs
@@ -133,6 +133,8 @@ namespace racman.offsets.ACIT
         public uint vorselon1SpaceCombat => gameVersion[GameID].vorselon1SpaceCombat;
         // 2 if Neffy 1 final room is done
         public uint neffy1finalRoom => gameVersion[GameID].neffy1finalRoom;
+        // 1 if GC2 was already visited
+        public uint wasGC2Visited => gameVersion[GameID].wasGC2Visited;
         // Weapon unlock
         public uint weapons => gameVersion[GameID].weapons;
         // Cutscenes array
@@ -192,6 +194,7 @@ namespace racman.offsets.ACIT
 
                 vorselon1SpaceCombat = 0xE26B20,
                 neffy1finalRoom = 0xE2C3A0,
+                wasGC2Visited = 0xE271E8,
 
                 mapTimerPtr = 0x4BA17930,
                 weapons = 0xE249F4,
@@ -253,6 +256,7 @@ namespace racman.offsets.ACIT
             public uint libraHPPtr { get; set; }
             public uint vorselon1SpaceCombat { get; set; }
             public uint neffy1finalRoom { get; set; }
+            public uint wasGC2Visited { get; set; }
             public uint weapons { get; set; }
             public uint[] cutscenesArray { get; set; }
         }

--- a/RaCTrainer/offsets/ACIT/ACITAddresses.cs
+++ b/RaCTrainer/offsets/ACIT/ACITAddresses.cs
@@ -22,14 +22,12 @@ namespace racman.offsets.ACIT
                 switch (GameID)
                 {
                     case "BCUS98124":
-                        IsAutosplitterSupported = true;
                         break;
                     case "NPUA80966":
                         IsAutosplitterSupported = true;
                         IsSelfKillSupported = true;
                         break;
                     case "BCES00511":
-                        IsAutosplitterSupported = true;
                         break;
                     default:
                         IsAutosplitterSupported = false;
@@ -47,6 +45,7 @@ namespace racman.offsets.ACIT
 
         public bool IsAutosplitterSupported { get; private set; }
         public bool IsSelfKillSupported { get; private set; }
+        public uint planetValue { get; set; }
 
         // (0 = in game, 1 = in main menu, 2 = in pause) (NOTE: first pause will result in a 1 for a second)
         public uint gameState1Ptr => gameVersion[GameID].gameState1Ptr;
@@ -65,7 +64,57 @@ namespace racman.offsets.ACIT
         // Current bolt count
         public uint boltCount => gameVersion[GameID].boltCount;
         // Ratchet's coordinates
-        public uint playerCoords => gameVersion[GameID].playerCoords;
+        public uint playerCoords
+        {
+            get
+            {
+                switch (planetValue)
+                {
+                    case 1:
+                        return gameVersion[GameID].pCoordsGC1;
+                    case 2:
+                        return gameVersion[GameID].pCoordsZolar;
+                    case 3:
+                        return gameVersion[GameID].pCoordsPhylaxS;
+                    case 4:
+                        return gameVersion[GameID].pCoordsVorselon;
+                    case 5:
+                        return gameVersion[GameID].pCoordsGC2;
+                    case 6:
+                        return gameVersion[GameID].pCoordsVelaS;
+                    case 7:
+                        return gameVersion[GameID].pCoordsMolonoth;
+                    case 8:
+                        return gameVersion[GameID].pCoordsAxiom;
+                    case 9:
+                        return gameVersion[GameID].pCoordsGC3;
+                    case 10:
+                        return gameVersion[GameID].pCoordsKorthosS;
+                    case 11:
+                        return gameVersion[GameID].pCoordsKrell;
+                    case 12:
+                        return gameVersion[GameID].pCoordsBattlePlex;
+                    case 13:
+                        return gameVersion[GameID].pCoordsZanifar;
+                    case 14:
+                        return gameVersion[GameID].pCoordsGC4;
+                    case 15:
+                        return gameVersion[GameID].pCoordsBerniliusS;
+                    case 16:
+                        return gameVersion[GameID].pCoordsGC5;
+                    case 17:
+                        return gameVersion[GameID].pCoordsNeffy;
+                    case 18:
+                        return gameVersion[GameID].pCoordsCorvusS;
+                    case 19:
+                        return gameVersion[GameID].pCoordsGC6;
+                    case 20:
+                        return gameVersion[GameID].pCoordsGC6;
+                    default:
+                        return 0;
+                }
+            }
+        }
         // The player's current health.
         public uint playerHealth => gameVersion[GameID].playerHealth;
         // Controller inputs mask address
@@ -78,6 +127,12 @@ namespace racman.offsets.ACIT
         public uint currentPlanet => gameVersion[GameID].currentPlanet;
         // Azimuth HP
         public uint azimuthHPPtr => gameVersion[GameID].azimuthHPPtr;
+        // Libra HP (backup 0x40E89510)
+        public uint libraHPPtr => gameVersion[GameID].libraHPPtr;
+        // 1 if Vorselon 1 space combat is done
+        public uint vorselon1SpaceCombat => gameVersion[GameID].vorselon1SpaceCombat;
+        // 2 if Neffy 1 final room is done
+        public uint neffy1finalRoom => gameVersion[GameID].neffy1finalRoom;
         // Weapon unlock
         public uint weapons => gameVersion[GameID].weapons;
         // Cutscenes array
@@ -96,12 +151,32 @@ namespace racman.offsets.ACIT
                 saveFileIDPtr = 0xE47338,
                 timerPtr = 0x40EBA460,
                 boltCount = 0xE24FE8,
-                playerCoords = 0xE240F0,
+                //playerCoords = 0xE240F0,
                 currentPlanet = 0xEF7E90,
                 azimuthHPPtr = 0x40E890AC
             };
             gameVersion["NPUA80966"] = new Addresses
             {
+                pCoordsGC1 = 0x0,
+                pCoordsZolar = 0x4A4E4800,
+                pCoordsPhylaxS = 0x0,
+                pCoordsVorselon = 0x4A392A70,
+                pCoordsGC2 = 0x0,
+                pCoordsVelaS = 0x0,
+                pCoordsMolonoth = 0x0,
+                pCoordsAxiom = 0x0,
+                pCoordsGC3 = 0x0,
+                pCoordsKorthosS = 0x0,
+                pCoordsKrell = 0x0,
+                pCoordsBattlePlex = 0x0,
+                pCoordsZanifar = 0x0,
+                pCoordsGC4 = 0x0,
+                pCoordsBerniliusS = 0x0,
+                pCoordsGC5 = 0x0,
+                pCoordsNeffy = 0x4A5E1980,
+                pCoordsCorvusS = 0x0,
+                pCoordsGC6 = 0x0,
+
                 gameState1Ptr = 0xFBA8C8,
                 cutsceneState1Ptr = 0xF6B3AC,
                 cutsceneState2Ptr = 0x40E9651C,
@@ -109,11 +184,15 @@ namespace racman.offsets.ACIT
                 saveFileIDPtr = 0xE472B8,
                 timerPtr = 0x40EBA460,
                 boltCount = 0xE24F68,
-                playerCoords = 0x4A4E4800,
                 inputOffset = 0xF6ABC8,
                 analogOffset = 0xF6AA24,
                 currentPlanet = 0xE896B4,
                 azimuthHPPtr = 0x40E890AC,
+                libraHPPtr = 0x40E893CC,
+
+                vorselon1SpaceCombat = 0xE26B20,
+                neffy1finalRoom = 0xE2C3A0,
+
                 mapTimerPtr = 0x4BA17930,
                 weapons = 0xE249F4,
                 cutscenesArray = new uint[] { 0x409AE5BC, 0x409AE620, 0x409AE6F4, 0x409AE784, 0x409AE7B4, 0x409AE814, 0x409AE844, 0x409AE874, 0x409AED84, 0x409AEDE4 }
@@ -127,7 +206,7 @@ namespace racman.offsets.ACIT
                 saveFileIDPtr = 0xE473B8,
                 timerPtr = 0x40EBADE0,
                 boltCount = 0xE25068,
-                playerCoords = 0xE24170,
+                //playerCoords = 0xE24170,
                 inputOffset = 0xF6AD48,
                 analogOffset = 0xF6ABA4,
                 currentPlanet = 0xE897B4,
@@ -137,6 +216,26 @@ namespace racman.offsets.ACIT
 
         private class Addresses
         {
+            public uint pCoordsGC1 { get; set; }
+            public uint pCoordsZolar { get; set; }
+            public uint pCoordsPhylaxS { get; set; }
+            public uint pCoordsVorselon { get; set; }
+            public uint pCoordsGC2 { get; set; }
+            public uint pCoordsVelaS { get; set; }
+            public uint pCoordsMolonoth { get; set; }
+            public uint pCoordsAxiom { get; set; }
+            public uint pCoordsGC3 { get; set; }
+            public uint pCoordsKorthosS { get; set; }
+            public uint pCoordsKrell { get; set; }
+            public uint pCoordsBattlePlex { get; set; }
+            public uint pCoordsZanifar { get; set; }
+            public uint pCoordsGC4 { get; set; }
+            public uint pCoordsBerniliusS { get; set; }
+            public uint pCoordsGC5 { get; set; }
+            public uint pCoordsNeffy { get; set; }
+            public uint pCoordsCorvusS { get; set; }
+            public uint pCoordsGC6 { get; set; }
+
             public uint gameState1Ptr { get; set; }
             public uint cutsceneState1Ptr { get; set; }
             public uint cutsceneState2Ptr { get; set; }
@@ -145,13 +244,15 @@ namespace racman.offsets.ACIT
             public uint timerPtr { get; set; }
             public uint mapTimerPtr { get; set; }
             public uint boltCount { get; set; }
-            public uint playerCoords { get; set; }
             public uint playerHealth { get; set; }
             public uint inputOffset { get; set; }
             public uint analogOffset { get; set; }
             public uint loadPlanet { get; set; }
             public uint currentPlanet { get; set; }
             public uint azimuthHPPtr { get; set; }
+            public uint libraHPPtr { get; set; }
+            public uint vorselon1SpaceCombat { get; set; }
+            public uint neffy1finalRoom { get; set; }
             public uint weapons { get; set; }
             public uint[] cutscenesArray { get; set; }
         }

--- a/RaCTrainer/offsets/ACIT/ACITAddresses.cs
+++ b/RaCTrainer/offsets/ACIT/ACITAddresses.cs
@@ -48,7 +48,7 @@ namespace racman.offsets.ACIT
         public uint planetValue { get; set; }
 
         // (0 = in game, 1 = in main menu, 2 = in pause) (NOTE: first pause will result in a 1 for a second)
-        public uint gameState1Ptr => gameVersion[GameID].gameState1Ptr;
+        public uint gameStatePtr => gameVersion[GameID].gameStatePtr;
         // indicates last opened scene (1 = save screen, 2 = load screen, 4 playing)
         public uint loadSaveState => gameVersion[GameID].loadSaveState;
         // Main Cutscenes (0 = in game, 1 = in cutscene)
@@ -152,7 +152,7 @@ namespace racman.offsets.ACIT
 
             gameVersion["BCUS98124"] = new Addresses
             {
-                gameState1Ptr = 0xFBADC8,
+                gameStatePtr = 0xFBADC8,
                 cutsceneState1Ptr = 0xF6B4AC,
                 cutsceneState2Ptr = 0x40E9651C,
                 cutsceneState3Ptr = 0xDF027C,
@@ -186,7 +186,7 @@ namespace racman.offsets.ACIT
                 pCoordsGimlick = 0x0,
                 pCoordsGC5 = 0x0,
 
-                gameState1Ptr = 0xFBA8C8,
+                gameStatePtr = 0xFBA8C8,
                 loadSaveState = 0xE472C4,
                 cutsceneState1Ptr = 0xF6B3AC,
                 cutsceneState2Ptr = 0x40E9651C,
@@ -212,7 +212,7 @@ namespace racman.offsets.ACIT
             };
             gameVersion["BCES00511"] = new Addresses
             {
-                gameState1Ptr = 0xFBAE48,
+                gameStatePtr = 0xFBAE48,
                 cutsceneState1Ptr = 0xF6B52C,
                 cutsceneState2Ptr = 0x40E96E9C,
                 cutsceneState3Ptr = 0x40E96E9C,
@@ -250,7 +250,7 @@ namespace racman.offsets.ACIT
             public uint pCoordsGimlick { get; set; }
             public uint pCoordsGC5 { get; set; }
 
-            public uint gameState1Ptr { get; set; }
+            public uint gameStatePtr { get; set; }
             public uint loadSaveState { get; set; }
             public uint cutsceneState1Ptr { get; set; }
             public uint cutsceneState2Ptr { get; set; }

--- a/RaCTrainer/offsets/ACIT/ACITAddresses.cs
+++ b/RaCTrainer/offsets/ACIT/ACITAddresses.cs
@@ -59,6 +59,8 @@ namespace racman.offsets.ACIT
         public uint saveFileIDPtr => gameVersion[GameID].saveFileIDPtr;
         // Timer
         public uint timerPtr => gameVersion[GameID].timerPtr;
+        // 1 if the game is loading, 0 otherwise
+        public uint isLoading => gameVersion[GameID].isLoading;
         // Map timer
         public uint mapTimerPtr => gameVersion[GameID].mapTimerPtr;
         // Current bolt count
@@ -185,6 +187,7 @@ namespace racman.offsets.ACIT
                 cutsceneState3Ptr = 0x4A4E5428,
                 saveFileIDPtr = 0xE472B8,
                 timerPtr = 0x40EBA460,
+                isLoading = 0xF23584,
                 boltCount = 0xE24F68,
                 inputOffset = 0xF6ABC8,
                 analogOffset = 0xF6AA24,
@@ -245,6 +248,7 @@ namespace racman.offsets.ACIT
             public uint cutsceneState3Ptr { get; set; }
             public uint saveFileIDPtr { get; set; }
             public uint timerPtr { get; set; }
+            public uint isLoading { get; set; }
             public uint mapTimerPtr { get; set; }
             public uint boltCount { get; set; }
             public uint playerHealth { get; set; }

--- a/RaCTrainer/offsets/ACIT/ACITAddresses.cs
+++ b/RaCTrainer/offsets/ACIT/ACITAddresses.cs
@@ -49,6 +49,8 @@ namespace racman.offsets.ACIT
 
         // (0 = in game, 1 = in main menu, 2 = in pause) (NOTE: first pause will result in a 1 for a second)
         public uint gameState1Ptr => gameVersion[GameID].gameState1Ptr;
+        // indicates last opened scene (1 = save screen, 2 = load screen, 4 playing)
+        public uint loadSaveState => gameVersion[GameID].loadSaveState;
         // Main Cutscenes (0 = in game, 1 = in cutscene)
         public uint cutsceneState1Ptr => gameVersion[GameID].cutsceneState1Ptr;
         // Animation Cutscenes (0 = in game, 1 = in cutscene)
@@ -103,15 +105,15 @@ namespace racman.offsets.ACIT
                     case 15:
                         return gameVersion[GameID].pCoordsBerniliusS;
                     case 16:
-                        return gameVersion[GameID].pCoordsGC5;
+                        return gameVersion[GameID].pCoordsVapedia;
                     case 17:
                         return gameVersion[GameID].pCoordsNeffy;
                     case 18:
                         return gameVersion[GameID].pCoordsCorvusS;
                     case 19:
-                        return gameVersion[GameID].pCoordsGC6;
+                        return gameVersion[GameID].pCoordsGimlick;
                     case 20:
-                        return gameVersion[GameID].pCoordsGC6;
+                        return gameVersion[GameID].pCoordsGC5;
                     default:
                         return 0;
                 }
@@ -137,6 +139,8 @@ namespace racman.offsets.ACIT
         public uint neffy1finalRoom => gameVersion[GameID].neffy1finalRoom;
         // 1 if GC2 was already visited
         public uint wasGC2Visited => gameVersion[GameID].wasGC2Visited;
+        // 1 if the first cutscene of the game is playing 0 otherwise (NOTE: this workds only on GC1) (backups 0x400473A4, 0x40047524, 0x4896B7C8)
+        public uint firstCutscene => gameVersion[GameID].firstCutscene;
         // Weapon unlock
         public uint weapons => gameVersion[GameID].weapons;
         // Cutscenes array
@@ -161,27 +165,29 @@ namespace racman.offsets.ACIT
             };
             gameVersion["NPUA80966"] = new Addresses
             {
-                pCoordsGC1 = 0x0,
+                pCoordsGC1 = 0xDE5590,
                 pCoordsZolar = 0x4A4E4800,
-                pCoordsPhylaxS = 0x0,
+                pCoordsPhylaxS = 0x490E2E80,
                 pCoordsVorselon = 0x4A392A70,
-                pCoordsGC2 = 0x0,
+                pCoordsGC2 = 0xDE5590,
                 pCoordsVelaS = 0x0,
                 pCoordsMolonoth = 0x0,
                 pCoordsAxiom = 0x0,
-                pCoordsGC3 = 0x0,
+                pCoordsGC3 = 0x4740C2B0,
                 pCoordsKorthosS = 0x0,
                 pCoordsKrell = 0x0,
                 pCoordsBattlePlex = 0x0,
                 pCoordsZanifar = 0x0,
-                pCoordsGC4 = 0x0,
+                pCoordsGC4 = 0x47D9C5B0,
                 pCoordsBerniliusS = 0x0,
-                pCoordsGC5 = 0x0,
+                pCoordsVapedia = 0x0,
                 pCoordsNeffy = 0x4A5E1980,
                 pCoordsCorvusS = 0x0,
-                pCoordsGC6 = 0x0,
+                pCoordsGimlick = 0x0,
+                pCoordsGC5 = 0x0,
 
                 gameState1Ptr = 0xFBA8C8,
+                loadSaveState = 0xE472C4,
                 cutsceneState1Ptr = 0xF6B3AC,
                 cutsceneState2Ptr = 0x40E9651C,
                 cutsceneState3Ptr = 0x4A4E5428,
@@ -198,6 +204,7 @@ namespace racman.offsets.ACIT
                 vorselon1SpaceCombat = 0xE26B20,
                 neffy1finalRoom = 0xE2C3A0,
                 wasGC2Visited = 0xE271E8,
+                firstCutscene = 0x40047224,
 
                 mapTimerPtr = 0x4BA17930,
                 weapons = 0xE249F4,
@@ -237,12 +244,14 @@ namespace racman.offsets.ACIT
             public uint pCoordsZanifar { get; set; }
             public uint pCoordsGC4 { get; set; }
             public uint pCoordsBerniliusS { get; set; }
-            public uint pCoordsGC5 { get; set; }
+            public uint pCoordsVapedia { get; set; }
             public uint pCoordsNeffy { get; set; }
             public uint pCoordsCorvusS { get; set; }
-            public uint pCoordsGC6 { get; set; }
+            public uint pCoordsGimlick { get; set; }
+            public uint pCoordsGC5 { get; set; }
 
             public uint gameState1Ptr { get; set; }
+            public uint loadSaveState { get; set; }
             public uint cutsceneState1Ptr { get; set; }
             public uint cutsceneState2Ptr { get; set; }
             public uint cutsceneState3Ptr { get; set; }
@@ -261,6 +270,7 @@ namespace racman.offsets.ACIT
             public uint vorselon1SpaceCombat { get; set; }
             public uint neffy1finalRoom { get; set; }
             public uint wasGC2Visited { get; set; }
+            public uint firstCutscene { get; set; }
             public uint weapons { get; set; }
             public uint[] cutscenesArray { get; set; }
         }

--- a/RaCTrainer/offsets/ACIT/ACITWeapon.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeapon.cs
@@ -23,7 +23,7 @@ namespace racman.offsets
             this.upgradealbe = upgradealbe;
         }
 
-        public void updateLevel(uint level)
+        public void UpdateLevel(uint level)
         {
             if (!upgradealbe)
             {

--- a/RaCTrainer/offsets/ACIT/ACITWeapon.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeapon.cs
@@ -10,7 +10,7 @@ namespace racman.offsets
         // the index in the unlock array
         public uint index { get; private set; }
         public uint level { get; private set; }
-        public bool isUnlocked { get; set; }
+        public bool IsUnlocked { get; set; }
         // if a gadget get's leveled up, it wont work properly
         public bool upgradealbe { get; private set; }
 
@@ -19,7 +19,7 @@ namespace racman.offsets
             this.name = name;
             this.index = index;
             this.level = 1;
-            this.isUnlocked = false;
+            this.IsUnlocked = false;
             this.upgradealbe = upgradealbe;
         }
 

--- a/RaCTrainer/offsets/ACIT/ACITWeapon.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeapon.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace racman.offsets
+{
+    public class ACITWeapon
+    {
+        internal Action<ACITWeapon> levelChanged;
+
+        public string name { get; private set; }
+        // the index in the unlock array
+        public uint index { get; private set; }
+        public uint level { get; private set; }
+        public bool isUnlocked { get; set; }
+        // if a gadget get's leveled up, it wont work properly
+        public bool upgradealbe { get; private set; }
+
+        public ACITWeapon(string name, uint index, bool upgradealbe)
+        {
+            this.name = name;
+            this.index = index;
+            this.level = 1;
+            this.isUnlocked = false;
+            this.upgradealbe = upgradealbe;
+        }
+
+        public void updateLevel(uint level)
+        {
+            if (!upgradealbe)
+            {
+                return;
+            }
+            this.level = level;
+            levelChanged?.Invoke(this);
+        }
+    }
+}

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -55,7 +55,7 @@ namespace racman.offsets
         {
             for (int i = 0; i < weaponCount; i++)
             {
-                weapons[i].isUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
+                weapons[i].IsUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
                 weapons[i].UpdateLevel(BitConverter.ToUInt32(memoryArray, (int)(weaponLevelOffset + (i * weaponMemoryLenght))) + 1);
             }
         }

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -28,28 +28,28 @@ namespace racman.offsets
         {
             weapons = new List<ACITWeapon>
             {
-                new ACITWeapon("Omniwrench", 0, 0, false),
-                new ACITWeapon("Time bomb", 1, 0, false),
-                new ACITWeapon("Mr Zurkon", 2, 0, false),
-                new ACITWeapon("Buzz blades", 3, 0, false),
-                new ACITWeapon("Negotiator", 4, 0, false),
-                new ACITWeapon("Sonic eruptor", 5, 0, false),
-                new ACITWeapon("Magnet launcher", 6, 0, false),
-                new ACITWeapon("Cryomine glove", 7, 0, false),
-                new ACITWeapon("Plasma striker", 8, 0, false),
-                new ACITWeapon("Dynamo of doom", 9, 0, false),
-                new ACITWeapon("Rift inducer", 10, 0, false),
-                new ACITWeapon("Tesla spikes", 11, 0, false),
-                new ACITWeapon("Groovitron glove", 12, 0, false),
-                new ACITWeapon("Chimp-o-matic", 13, 0, false),
-                new ACITWeapon("Ryno V", 14, 0, false),
-                new ACITWeapon("Spiral of death", 15, 0, false),
-                new ACITWeapon("Constructo pistol", 16, 0, false),
-                new ACITWeapon("Constructo bomb", 17, 0, false),
-                new ACITWeapon("Constructo shotgun", 18, 0, false),
-                new ACITWeapon("Swingshot", 19, 0, false),
-                new ACITWeapon("Omnisoaker", 20, 0, false),
-                new ACITWeapon("Hoverboots", 21, 0, false),
+                new ACITWeapon("Omniwrench", 0, false),
+                new ACITWeapon("Time bomb", 1, false),
+                new ACITWeapon("Mr Zurkon", 2, true),
+                new ACITWeapon("Buzz blades", 3, true),
+                new ACITWeapon("Negotiator", 4, true),
+                new ACITWeapon("Sonic eruptor", 5, true),
+                new ACITWeapon("Magnet launcher", 6, true),
+                new ACITWeapon("Cryomine glove", 7, true),
+                new ACITWeapon("Plasma striker", 8, true),
+                new ACITWeapon("Dynamo of doom", 9, true),
+                new ACITWeapon("Rift inducer", 10, true),
+                new ACITWeapon("Tesla spikes", 11, true),
+                new ACITWeapon("Groovitron glove", 12, true),
+                new ACITWeapon("Chimp-o-matic", 13, true),
+                new ACITWeapon("Ryno V", 14, true),
+                new ACITWeapon("Spiral of death", 15, true),
+                new ACITWeapon("Constructo pistol", 16, true),
+                new ACITWeapon("Constructo bomb", 17, true),
+                new ACITWeapon("Constructo shotgun", 18, true),
+                new ACITWeapon("Swingshot", 19, false),
+                new ACITWeapon("Omnisoaker", 20, false),
+                new ACITWeapon("Hoverboots", 21, false),
             };
         }
 
@@ -58,7 +58,7 @@ namespace racman.offsets
             for (int i = 0; i < weaponCount; i++)
             {
                 weapons[i].isUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
-                weapons[i].level = (uint)memoryArray[weaponLevelOffset + (i * weaponMemoryLenght)] + 1;
+                weapons[i].updateLevel((uint)memoryArray[weaponLevelOffset + (i * weaponMemoryLenght)] + 1);
                 Console.WriteLine(weapons[i].name + " " + weapons[i].level);
             }
         }
@@ -66,18 +66,33 @@ namespace racman.offsets
 
     public class ACITWeapon
     {
+        internal Action<object, object> levelChanged;
+
         public string name { get; private set; }
         // the index in the unlock array
         public uint index { get; private set; }
-        public uint level { get; set; }
+        public uint level { get; private set; }
         public bool isUnlocked { get; set; }
+        // if a gadget get's leveled up, it wont work properly
+        public bool upgradealbe { get; private set; }
 
-        public ACITWeapon(string name, uint index, uint level, bool isUnlocked)
+        public ACITWeapon(string name, uint index, bool upgradealbe)
         {
             this.name = name;
             this.index = index;
+            this.level = 1;
+            this.isUnlocked = false;
+            this.upgradealbe = upgradealbe;
+        }
+
+        public void updateLevel(uint level)
+        {
+            if (!upgradealbe)
+            {
+                return;
+            }
             this.level = level;
-            this.isUnlocked = isUnlocked;
+            levelChanged?.Invoke(this, null);
         }
     }
 }

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -22,11 +22,9 @@ namespace racman.offsets
 
         public static uint weaponIndex = 0x17;
 
-        public List<ACITWeapon> weapons { get; private set; }
-
-        public ACITWeaponFactory()
+        public static List<ACITWeapon> GetWeapons()
         {
-            weapons = new List<ACITWeapon>
+            return new List<ACITWeapon>
             {
                 new ACITWeapon("Omniwrench", 0, false),
                 new ACITWeapon("Time bomb", 1, false),
@@ -53,11 +51,12 @@ namespace racman.offsets
             };
         }
 
-        public void updateWeapons(byte[] memoryArray)
+        public static void updateWeapons(byte[] memoryArray, List<ACITWeapon> weapons)
         {
             for (int i = 0; i < weaponCount; i++)
             {
                 weapons[i].isUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
+                weapons[i].UpdateLevel(BitConverter.ToUInt32(memoryArray, (int)(weaponLevelOffset + (i * weaponMemoryLenght))) + 1);
             }
         }
     }

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -59,7 +59,6 @@ namespace racman.offsets
             {
                 weapons[i].isUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
                 weapons[i].updateLevel((uint)memoryArray[weaponLevelOffset + (i * weaponMemoryLenght)] + 1);
-                Console.WriteLine(weapons[i].name + " " + weapons[i].level);
             }
         }
     }

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -61,36 +61,4 @@ namespace racman.offsets
             }
         }
     }
-
-    public class ACITWeapon
-    {
-        internal Action<ACITWeapon> levelChanged;
-
-        public string name { get; private set; }
-        // the index in the unlock array
-        public uint index { get; private set; }
-        public uint level { get; private set; }
-        public bool isUnlocked { get; set; }
-        // if a gadget get's leveled up, it wont work properly
-        public bool upgradealbe { get; private set; }
-
-        public ACITWeapon(string name, uint index, bool upgradealbe)
-        {
-            this.name = name;
-            this.index = index;
-            this.level = 1;
-            this.isUnlocked = false;
-            this.upgradealbe = upgradealbe;
-        }
-
-        public void updateLevel(uint level)
-        {
-            if (!upgradealbe)
-            {
-                return;
-            }
-            this.level = level;
-            levelChanged?.Invoke(this);
-        }
-    }
 }

--- a/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
+++ b/RaCTrainer/offsets/ACIT/ACITWeaponFactory.cs
@@ -58,14 +58,13 @@ namespace racman.offsets
             for (int i = 0; i < weaponCount; i++)
             {
                 weapons[i].isUnlocked = BitConverter.ToBoolean(memoryArray, (int)(weaponUnlockOffset + (i * weaponMemoryLenght)));
-                weapons[i].updateLevel((uint)memoryArray[weaponLevelOffset + (i * weaponMemoryLenght)] + 1);
             }
         }
     }
 
     public class ACITWeapon
     {
-        internal Action<object, object> levelChanged;
+        internal Action<ACITWeapon> levelChanged;
 
         public string name { get; private set; }
         // the index in the unlock array
@@ -91,7 +90,7 @@ namespace racman.offsets
                 return;
             }
             this.level = level;
-            levelChanged?.Invoke(this, null);
+            levelChanged?.Invoke(this);
         }
     }
 }

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -9,32 +9,6 @@ namespace racman
 {
     public class acit : IGame, IAutosplitterAvailable
     {
-        public dynamic Planets = new
-        {
-            agorian_arena = ("Agorian Arena"),
-            axiom_city = ("Axion City"),
-            front_end = ("Front End"),
-            galacton_ship = ("Vorselon Ship"),
-            gimlick_valley = ("Gimlick Valey"),
-            great_clock_a = ("Great Clock 1"),
-            great_clock_b = ("Great Clock 2"),
-            great_clock_c = ("Great Clock 3"),
-            great_clock_d = ("Great Clock 4"),
-            great_clock_e = ("Great Clock 5"),
-            insomniac_museum = ("Insomniac Museum"),
-            krell_canyon = ("Krell Canyon"),
-            molonoth = ("Molonoth Fields"),
-            nefarious_statio = ("Nefarious Station"),
-            space_sector_1 = ("Space Sector 1"),
-            space_sector_2 = ("Space Sector 2"),
-            space_sector_3 = ("Space Sector 3"),
-            space_sector_4 = ("Space Sector 4"),
-            space_sector_5 = ("Space Sector 5"),
-            tombli = ("Tombli Outpost"),
-            valkyrie_fleet = ("Valkyrie Fleet"),
-            zolar_forest = ("Zolar Forest")
-        };
-
         public static ACITAddresses addr;
 
         public bool HasInputDisplay => addr.inputOffset > 0 && addr.analogOffset > 0 && addr.currentPlanet > 0;

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -53,6 +53,7 @@ namespace racman
             (addr.neffy1finalRoom, 4),      // neffy 1 final room
             (addr.wasGC2Visited, 4),         // neffy 2 final room
             (addr.timerPtr, 4),             // timer
+            (addr.isLoading, 4),            // is loading
         };
 
         public override void ResetLevelFlags()

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -115,7 +115,7 @@ namespace racman
         /// <param name="unlockState"></param>
         public void setUnlockState(ACITWeapon weapon, bool unlockState)
         {
-            weapon.isUnlocked = unlockState;
+            weapon.IsUnlocked = unlockState;
             api.WriteMemory(pid, addr.weapons + (weapon.index * ACITWeaponFactory.weaponMemoryLenght) + ACITWeaponFactory.weaponUnlockOffset, BitConverter.GetBytes(unlockState));
 
         }

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -51,9 +51,11 @@ namespace racman
             (addr.libraHPPtr, 4),           // libra HP
             (addr.vorselon1SpaceCombat, 4), // vorselon 1 space combat
             (addr.neffy1finalRoom, 4),      // neffy 1 final room
-            (addr.wasGC2Visited, 4),         // neffy 2 final room
+            (addr.wasGC2Visited, 4),        // neffy 2 final room
             (addr.timerPtr, 4),             // timer
             (addr.isLoading, 4),            // is loading
+            (addr.firstCutscene, 4),        // first cutscene
+            (addr.loadSaveState, 4),        // load save state
         };
 
         public override void ResetLevelFlags()

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -158,6 +158,8 @@ namespace racman
             api.WriteMemory(pid, addr.weapons + (weaponIndex * ACITWeaponFactory.weaponMemoryLenght) + ACITWeaponFactory.weaponlevel4Offset, BitConverter.GetBytes(xp));
 
             api.WriteMemory(pid, addr.weapons + (weaponIndex * ACITWeaponFactory.weaponMemoryLenght) + ACITWeaponFactory.weaponLevelOffset, BitConverter.GetBytes(level));
+
+            weapon.updateLevel(level + 1);
         }
 
         private byte[][] ReadCutsceneStrings()

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -47,13 +47,11 @@ namespace racman
             (addr.cutsceneState3Ptr, 4),    // cutscene state3
             (addr.saveFileIDPtr, 4),        // save file ID
             (addr.boltCount, 4),            // bolt count
-            (addr.playerCoords, 4),         // player X coord
-            (addr.playerCoords + 0x8, 4),   // player Y coord
-            (addr.playerCoords + 0x4, 4),   // player Z coord
             (addr.azimuthHPPtr, 4),         // azimuth HP
             (addr.libraHPPtr, 4),           // libra HP
             (addr.vorselon1SpaceCombat, 4), // vorselon 1 space combat
             (addr.neffy1finalRoom, 4),      // neffy 1 final room
+            (addr.wasGC2Visited, 4),         // neffy 2 final room
             (addr.timerPtr, 4),             // timer
         };
 

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -41,7 +41,7 @@ namespace racman
         public IEnumerable<(uint addr, uint size)> AutosplitterAddresses => new (uint, uint)[]
         {
             (addr.currentPlanet, 4),        // current planet
-            (addr.gameState1Ptr, 4),        // game state1
+            (addr.gameStatePtr, 4),        // game state1
             (addr.cutsceneState1Ptr, 4),    // cutscene state1
             (addr.cutsceneState2Ptr, 4),    // cutscene state2
             (addr.cutsceneState3Ptr, 4),    // cutscene state3

--- a/RaCTrainer/offsets/ACIT/acit.cs
+++ b/RaCTrainer/offsets/ACIT/acit.cs
@@ -144,6 +144,10 @@ namespace racman
         /// <param name="level"></param>
         public void setWeaponLevel(ACITWeapon weapon, uint level)
         {
+            if (!weapon.upgradealbe)
+            {
+                return;
+            }
             level--;
             uint xp = (uint)(level == 0 ? 0 : 0xFF);
             uint weaponIndex = weapon.index;
@@ -153,7 +157,7 @@ namespace racman
             api.WriteMemory(pid, addr.weapons + (weaponIndex * ACITWeaponFactory.weaponMemoryLenght) + ACITWeaponFactory.weaponlevel4Offset, BitConverter.GetBytes(xp));
 
             api.WriteMemory(pid, addr.weapons + (weaponIndex * ACITWeaponFactory.weaponMemoryLenght) + ACITWeaponFactory.weaponLevelOffset, BitConverter.GetBytes(level));
-            weapon.level = level;
+            weapon.updateLevel(level + 1);
         }
 
         private byte[][] ReadCutsceneStrings()

--- a/RaCTrainer/offsets/RAC4/BotsUnlocks.cs
+++ b/RaCTrainer/offsets/RAC4/BotsUnlocks.cs
@@ -1,0 +1,17 @@
+﻿namespace racman.offsets.RAC4
+{
+    public class BotsUnlocks
+    {
+        public string name { get; private set; }
+        // the index in the unlock array
+        public uint index { get; private set; }
+        public bool IsUnlocked { get; set; }
+
+        public BotsUnlocks(string name, uint index)
+        {
+            this.name = name;
+            this.index = index;
+            this.IsUnlocked = false;
+        }
+    }
+}

--- a/RaCTrainer/offsets/RAC4/BotsUnlocksFactory.cs
+++ b/RaCTrainer/offsets/RAC4/BotsUnlocksFactory.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace racman.offsets.RAC4
+{
+    public class BotsUnlocksFactory
+    {
+        public static uint UpgradesCount = 16;
+
+        public static List<BotsUnlocks> GetUpgrades()
+        {
+            return new List<BotsUnlocks>
+            {
+                new BotsUnlocks("Pistol Flux LX", 0),
+                new BotsUnlocks("Range Warrior", 1),
+                new BotsUnlocks("Bogo", 2),
+                new BotsUnlocks("Alpha Ravager", 3),
+                new BotsUnlocks("Beta Ravager", 4),
+                new BotsUnlocks("EMP Grenade", 5),
+                new BotsUnlocks("Hacker Ray", 6),
+                new BotsUnlocks("Shield Link", 7),
+                new BotsUnlocks("Grind Cable", 8),
+                new BotsUnlocks("Go-Comet A", 9),
+                new BotsUnlocks("Go-Comet X", 10),
+                new BotsUnlocks("Go-Comet XR", 11),
+                new BotsUnlocks("Hyper-Tron", 12),
+                new BotsUnlocks("Dreadinator", 13),
+                new BotsUnlocks("DZ Ultra", 14),
+                new BotsUnlocks("Ultranator", 15),
+            };
+        }
+    }
+}

--- a/RaCTrainer/offsets/RAC4/rac4.cs
+++ b/RaCTrainer/offsets/RAC4/rac4.cs
@@ -16,6 +16,10 @@ namespace racman
         public uint infobotFlags => throw new System.NotImplementedException();
         public uint moviesFlags => throw new System.NotImplementedException();
 
+        public uint botsUnlock => 0x9D2775;
+        // unlocks are not saved, until the save flag is set to 1
+        public uint botsUnlockSave => 0x9C3325;
+
         // Vox HP
         public uint voxHP => 0x449BEAD0;
 
@@ -66,6 +70,8 @@ namespace racman
             (addr.tutorialFlags, 4),    // tutorial flags
             (addr.isLoading, 4),        // loading boolean
         };
+
+        //public void SetUnlockState()
 
         public override void ResetLevelFlags()
         {

--- a/RaCTrainer/racman.csproj
+++ b/RaCTrainer/racman.csproj
@@ -132,6 +132,8 @@
     <Compile Include="offsets\ACIT\ACITAddresses.cs" />
     <Compile Include="offsets\ACIT\ACITWeapon.cs" />
     <Compile Include="offsets\ACIT\ACITWeaponFactory.cs" />
+    <Compile Include="offsets\RAC4\BotsUnlocks.cs" />
+    <Compile Include="offsets\RAC4\BotsUnlocksFactory.cs" />
     <Compile Include="RAC2\RC2Unlocks.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/RaCTrainer/racman.csproj
+++ b/RaCTrainer/racman.csproj
@@ -130,6 +130,7 @@
     </Compile>
     <Compile Include="Memory\RPCS3.cs" />
     <Compile Include="offsets\ACIT\ACITAddresses.cs" />
+    <Compile Include="offsets\ACIT\ACITWeapon.cs" />
     <Compile Include="offsets\ACIT\ACITWeaponFactory.cs" />
     <Compile Include="RAC2\RC2Unlocks.cs">
       <SubType>Form</SubType>

--- a/RaCTrainer/racman.csproj
+++ b/RaCTrainer/racman.csproj
@@ -156,6 +156,12 @@
     <Compile Include="MemoryForm.Designer.cs">
       <DependentUpon>MemoryForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="RAC4\RAC4BotsUnlocks.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="RAC4\RAC4BotsUnlocks.Designer.cs">
+      <DependentUpon>RAC4BotsUnlocks.cs</DependentUpon>
+    </Compile>
     <Compile Include="RacmanScripting.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -265,6 +271,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="RAC2\RAC2JPForm.resx">
       <DependentUpon>RAC2JPForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="RAC4\RAC4BotsUnlocks.resx">
+      <DependentUpon>RAC4BotsUnlocks.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="RacmanScripting.resx">
       <DependentUpon>RacmanScripting.cs</DependentUpon>

--- a/racman.sln
+++ b/racman.sln
@@ -14,6 +14,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0909BCDB-6DF1-4F1B-B2F9-67AF696E7325}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{0909BCDB-6DF1-4F1B-B2F9-67AF696E7325}.Debug|Any CPU.Build.0 = Debug|x64
 		{0909BCDB-6DF1-4F1B-B2F9-67AF696E7325}.Debug|x64.ActiveCfg = Debug|x64
 		{0909BCDB-6DF1-4F1B-B2F9-67AF696E7325}.Debug|x64.Build.0 = Debug|x64
 		{0909BCDB-6DF1-4F1B-B2F9-67AF696E7325}.Release|Any CPU.ActiveCfg = Release|x64


### PR DESCRIPTION
ACIT:
 - weapons can now be leveled up, excluding gadgets. This change was implemented cuz gadgets at a level higher than 1 do not function properly
 - the weapon level is now displayed in the unlocks form
 - additional self-kill addresses have been added
 - autosplitter is now working (I also did a test run the check if it is ok)
 - some adjustments are needed for the autosplitter start and reset, but they are in a satisfactory state

RAC4:
- now it is possible to unlock or disable bot upgrades

General
 - I have re-enabled the VS build on pressing F5