### PR TITLE
UYA autosplitter fixes and input display fix

### DIFF
--- a/RaCTrainer/InputDisplay.cs
+++ b/RaCTrainer/InputDisplay.cs
@@ -183,6 +183,9 @@ namespace racman
             controllerSkin = ControllerSkin.Load($"controllerskins\\{skinName}");
 
             func.ChangeFileLines("config.txt", skinComboBox.SelectedIndex.ToString(), "InputDisplaySkin");
+
+            this.Width = Math.Max(controllerSkin.buttons["base"].spriteWidth + 50, this.Width);
+            this.Height = Math.Max(controllerSkin.buttons["base"].spriteHeight + 50, this.Height);
         }
 
         private void InputDisplay_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
## General
- Input display form now resizes to fit input display skins of different sizes

## UYA
### Autosplitter
- Fixed a bug that caused long loads to be incorrectly removed when flying to Metropolis from the ranger missions.
- Removed long load counter option (it's confusing to set up, and I think it's redundant when long loads are removed from game time)
- Re-added koros bolt 2 split option